### PR TITLE
\xi banned from being initialized at 0

### DIFF
--- a/src/structures/AbstractScalingModel/abstractscalingmodel.jl
+++ b/src/structures/AbstractScalingModel/abstractscalingmodel.jl
@@ -176,8 +176,12 @@ end
 
 function fit_mle_gradient_free(pd_type::Type{<:AbstractScalingModel}, data::IDFdata, d₀::Real, initialvalues::AbstractVector{<:Real})
 
-    θ₀ = IDFCurves.map_to_real_space(pd_type,initialvalues)
+    if initialvalues[3] == 0.0 # the shape parameter can't be initalized at 0.0
+        initialvalues[3] = 0.0001
+    end
 
+    θ₀ = IDFCurves.map_to_real_space(pd_type,initialvalues)
+    
     fobj(θ::DenseVector{<:Real}) = -loglikelihood(pd_type(d₀, map_to_param_space(pd_type, θ)...), data)
 
     @assert fobj(θ₀) < Inf "The initial value vector is not a member of the set of possible solutions. At least one data lies outside the distribution support."
@@ -198,6 +202,10 @@ end
 
 
 function fit_mle(pd_type::Type{<:AbstractScalingModel}, data::IDFdata, d₀::Real, initialvalues::AbstractVector{<:Real})
+
+    if initialvalues[3] == 0.0 # the shape parameter can't be initalized at 0.0
+        initialvalues[3] = 0.0001
+    end
 
     θ₀ = IDFCurves.map_to_real_space(pd_type,initialvalues)
 

--- a/src/structures/DependentScalingModel/dependentscalingmodel.jl
+++ b/src/structures/DependentScalingModel/dependentscalingmodel.jl
@@ -83,6 +83,10 @@ end
 
 function fit_mle(pd::Type{<:DependentScalingModel}, data::IDFdata, d₀::Real, initialvalues::AbstractArray{<:Real})
 
+    if initialvalues[3] == 0.0 # the shape parameter can't be initalized at 0.0
+        initialvalues[3] = 0.0001
+    end
+
     θ₀ = [IDFCurves.map_to_real_space(IDFCurves.getmarginaltype(pd), initialvalues[1:5])..., log(initialvalues[6]), log(initialvalues[7])]
 
     model(θ::DenseVector{<:Real}) = IDFCurves.construct_model(pd, data, d₀, θ)

--- a/test/structures/AbstractScalingModel/SimpleScaling_test.jl
+++ b/test/structures/AbstractScalingModel/SimpleScaling_test.jl
@@ -114,12 +114,16 @@ data = IDFdata(df, "Year", duration_dict)
 @testset "fit_mle(::SimpleScaling)" begin
 
     fd = IDFCurves.fit_mle_gradient_free(SimpleScaling, data, 1, [20, 5, .04, .76])
-
     @test [params(fd)...] ≈ [18.1366, 5.2874, 0.0486, 0.6942] rtol=.1
+    fd2 = IDFCurves.fit_mle_gradient_free(SimpleScaling, data, 1, [20, 5, .0, .76])
+    @test [params(fd2)...] ≈ [params(fd)...] rtol=.1
+    @test shape(fd2) != 0.0
 
     fd = IDFCurves.fit_mle(SimpleScaling, data, 1, [20, 5, .04, .76])
-
     @test [params(fd)...] ≈ [18.1366, 5.2874, 0.0486, 0.6942] rtol=.1
+    fd2 = IDFCurves.fit_mle(SimpleScaling, data, 1, [20, 5, .0, .76])
+    @test [params(fd2)...] ≈ [params(fd)...] rtol=.1
+    @test shape(fd2) != 0.0
 
     @testset "hessian(::SimpleScaling, data)" begin
     

--- a/test/structures/AbstractScalingModel/dGEV_test.jl
+++ b/test/structures/AbstractScalingModel/dGEV_test.jl
@@ -115,12 +115,16 @@ data = IDFdata(df, "Year", duration_dict)
 @testset "fit_mle(::dGEV)" begin
 
     fd = IDFCurves.fit_mle_gradient_free(dGEV, data, 1, [20, 5, .04, .76, .07])
-
     @test [params(fd)...] ≈ [19.7911, 5.5938, 0.0405, 0.7609, 0.0681] rtol=.1
+    fd2 = IDFCurves.fit_mle_gradient_free(dGEV, data, 1, [20, 5, .0, .76, .07])
+    @test [params(fd2)...] ≈ [params(fd)...] rtol=.1
+    @test shape(fd2) != 0.0
 
     fd = IDFCurves.fit_mle(dGEV, data, 1, [20, 5, .04, .76, .07])
-
     @test [params(fd)...] ≈ [19.7911, 5.5938, 0.0405, 0.7609, 0.0681] rtol=.1
+    fd2 = IDFCurves.fit_mle(dGEV, data, 1, [20, 5, .0, .76, .07])
+    @test [params(fd2)...] ≈ [params(fd)...] rtol=.1
+    @test shape(fd2) != 0.0
 
     @testset "hessian(::dGEV, data)" begin
     


### PR DESCRIPTION
if initial value of $\xi$ is $0$, then changed to be $0.0004$. Not elegant but works well in practice. Would be better to use `eps()`, but for now it creates problems (see [issue 28](https://github.com/JuliaExtremes/IDFCurves.jl/issues/28))